### PR TITLE
adds support for multiple primary key columns

### DIFF
--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -40,12 +40,22 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
   end
 
   defp total_entries(query, repo) do
-    query
+    # select count(*) from (select a, b from t group by a, b) x
+    # equivalent: select count(distinct(a, b)) from t
+    
+    primary_keys = query.from
+      |> elem(1)
+      |> apply(:__schema__, [:primary_key])
+    
+    base_query = query
       |> exclude(:order_by)
       |> exclude(:preload)
       |> exclude(:select)
       |> exclude(:group_by)
-      |> select([m], fragment("count(*)"))
+      |> group_by([x], ^primary_keys)
+      |> select([x], map(x, ^primary_keys))
+    
+    from(subquery(base_query), select: fragment("count(*)"))
       |> repo.one!
   end
 

--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -40,19 +40,13 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
   end
 
   defp total_entries(query, repo) do
-    primary_key =
-      query.from
-      |> elem(1)
-      |> apply(:__schema__, [:primary_key])
-      |> hd
-
     query
-    |> exclude(:order_by)
-    |> exclude(:preload)
-    |> exclude(:select)
-    |> exclude(:group_by)
-    |> select([m], count(field(m, ^primary_key), :distinct))
-    |> repo.one!
+      |> exclude(:order_by)
+      |> exclude(:preload)
+      |> exclude(:select)
+      |> exclude(:group_by)
+      |> select([m], fragment("count(*)"))
+      |> repo.one!
   end
 
   defp total_pages(total_entries, page_size) do


### PR DESCRIPTION
I have an Ecto model which uses multiple primary keys and it does not get counted correctly without this patch.

```
defmodule Mercury.VirtualModel.DuplicateSet do
  use Mercury.Model.Base

  @primary_key false
  schema "" do
    field :school_id, Ecto.UUID, primary_key: true
    field :datum, :string, primary_key: true
    field :object_ids, {:array, Ecto.UUID}
  end
end
```
