### PR TITLE
Exclude order_by when counting entries

### DIFF
--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -32,6 +32,7 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
       query
       |> exclude(:preload)
       |> exclude(:select)
+      |> exclude(:order_by)
       |> subquery
       |> select(count("*"))
       |> repo.one

--- a/test/scrivener/paginator/ecto/query_test.exs
+++ b/test/scrivener/paginator/ecto/query_test.exs
@@ -89,6 +89,18 @@ defmodule Scrivener.Paginator.Ecto.QueryTest do
       assert page.total_entries == 7
     end
 
+    test "it handles complex order_by" do
+      create_posts()
+
+      page =
+        Post
+        |> select([p], fragment("? as aliased_title", p.title))
+        |> order_by([p], fragment("aliased_title"))
+        |> Scrivener.Ecto.Repo.paginate
+
+      assert page.total_entries == 7
+    end
+
     test "can be provided the current page and page size as a params map" do
       posts = create_posts()
 


### PR DESCRIPTION
Previously when attempting to use a fragment in an order_by query, the
following error would be raised:

> ** (Postgrex.Error) ERROR 42703 (undefined_column): column
> "aliased_title" does not exist

The order of the results is not relevant when simply counting the
totals and has been excluded from the query.