### PR TITLE
Return 1 for total_pages on 0 entries

### DIFF
--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -40,6 +40,7 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
     total_entries || 0
   end
 
+  defp total_pages(0, _), do: 1
   defp total_pages(total_entries, page_size) do
     (total_entries / page_size) |> Float.ceil |> round
   end


### PR DESCRIPTION
When 0 entries are found `page_number` will be 1 so `total_pages` should also be 1