### PR TITLE
implement new pagination method using last_seen_id (as opposed to offset)

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -6,7 +6,8 @@ config :scrivener_ecto, Scrivener.Ecto.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool: Ecto.Adapters.SQL.Sandbox,
   database: "scrivener_test",
-  username: System.get_env("SCRIVENER_ECTO_DB_USER") || System.get_env("USER")
+  username: System.get_env("PG_DB_USER"),
+  password: System.get_env("PG_DB_PASSWORD")
 
 config :logger, :console,
   level: :error

--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -6,8 +6,14 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
   @moduledoc false
 
   @spec paginate(Ecto.Query.t, Scrivener.Config.t) :: Scrivener.Page.t
-  def paginate(query, %Config{page_size: page_size, page_number: page_number, module: repo, caller: caller}) do
+  def paginate(query, %Config{page_size: page_size, page_number: page_number, last_seen_id: last_seen_id, module: repo, caller: caller}) do
     total_entries = total_entries(query, repo, caller)
+    entries =
+      if is_nil(last_seen_id) == false do
+        entries_no_offset(query, repo, last_seen_id, page_size, caller)
+      else
+        entries(query, repo, page_number, page_size, caller)
+      end
 
     %Page{
       page_size: page_size,
@@ -24,6 +30,13 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
     query
     |> limit(^page_size)
     |> offset(^offset)
+    |> repo.all(caller: caller)
+  end
+
+  defp entries_no_offset(query, repo, last_seen_id, page_size, caller) do
+    query
+    |> limit(^page_size)
+    |> where([p], p.id > ^last_seen_id)
     |> repo.all(caller: caller)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule Scrivener.Ecto.Mixfile do
 
   defp deps do
     [
-      {:scrivener, "~> 2.3"},
+      {:scrivener, "~> 2.4.0-dev", git: "https://github.com/egeersoz/scrivener.git"},
       {:ecto, "~> 2.0"},
       {:dialyxir, "~> 0.5.0", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -8,4 +8,5 @@
   "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_spec": {:hex, :ex_spec, "1.0.0", "b1e791072fecbf80c725adf45e7cbdf3d96af3765638a1f1547824706ece4bc9", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
-  "postgrex": {:hex, :postgrex, "0.13.1", "ebf17b7348922af9db8b4d70f946328ab9ef5123526bf05567d9306393fce104", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"}}
+  "postgrex": {:hex, :postgrex, "0.13.1", "ebf17b7348922af9db8b4d70f946328ab9ef5123526bf05567d9306393fce104", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
+  "scrivener": {:git, "https://github.com/egeersoz/scrivener.git", "96476f82d86409def71ccac89d4f613177fac6ff", []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [], [], "hexpm"},
+%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "db_connection": {:hex, :db_connection, "1.1.1", "f9d246e8f65b9490945cf7360875eee18fcec9a0115207603215eb1fd94c39ef", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
@@ -8,5 +8,4 @@
   "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_spec": {:hex, :ex_spec, "1.0.0", "b1e791072fecbf80c725adf45e7cbdf3d96af3765638a1f1547824706ece4bc9", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
-  "postgrex": {:hex, :postgrex, "0.13.1", "ebf17b7348922af9db8b4d70f946328ab9ef5123526bf05567d9306393fce104", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
-  "scrivener": {:hex, :scrivener, "2.3.0", "16b1d744202d47233798205447b35592d96a209241c566304f84ddef63c718b2", [:mix], [], "hexpm"}}
+  "postgrex": {:hex, :postgrex, "0.13.1", "ebf17b7348922af9db8b4d70f946328ab9ef5123526bf05567d9306393fce104", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"}}

--- a/test/scrivener/paginator/ecto/query_test.exs
+++ b/test/scrivener/paginator/ecto/query_test.exs
@@ -26,6 +26,68 @@ defmodule Scrivener.Paginator.Ecto.QueryTest do
     end)
   end
 
+  defp create_posts_with_comments do
+      post_1 = %Post{title: "Title 1", body: "Body 1", published: true}
+      |> Scrivener.Ecto.Repo.insert!
+      post_2 = %Post{title: "Title 2", body: "Body 2", published: true}
+      |> Scrivener.Ecto.Repo.insert!
+      post_3 = %Post{title: "Title 3", body: "Body 3", published: true}
+      |> Scrivener.Ecto.Repo.insert!
+      post_4 = %Post{title: "Title 4", body: "Body 4", published: true}
+      |> Scrivener.Ecto.Repo.insert!
+      post_5 = %Post{title: "Title 5", body: "Body 5", published: true}
+      |> Scrivener.Ecto.Repo.insert!
+      post_6 = %Post{title: "Title 6", body: "Body 6", published: true}
+      |> Scrivener.Ecto.Repo.insert!
+      post_7 = %Post{title: "Title 7", body: "Body 7", published: true}
+      |> Scrivener.Ecto.Repo.insert!
+
+      %Comment{body: "Belongs to post_1", post_id: post_1.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_2", post_id: post_2.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_2", post_id: post_2.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_3", post_id: post_3.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_3", post_id: post_3.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_3", post_id: post_3.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_4", post_id: post_4.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_4", post_id: post_4.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_4", post_id: post_4.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_4", post_id: post_4.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_5", post_id: post_5.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_5", post_id: post_5.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_5", post_id: post_5.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_5", post_id: post_5.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_5", post_id: post_5.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_6", post_id: post_6.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_6", post_id: post_6.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_6", post_id: post_6.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_6", post_id: post_6.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_6", post_id: post_6.id}
+      |> Scrivener.Ecto.Repo.insert!
+      %Comment{body: "Belongs to post_6", post_id: post_6.id}
+      |> Scrivener.Ecto.Repo.insert!
+
+     post_1.id
+  end
+
   defp create_key_values do
     Enum.map(1..10, fn i ->
       %KeyValue{
@@ -36,6 +98,26 @@ defmodule Scrivener.Paginator.Ecto.QueryTest do
   end
 
   describe "paginate" do
+    test "paginates with last_seen_id" do
+      last_seen_id = create_posts_with_comments()
+
+      query =
+        from p in Post,
+        left_join: c in assoc(p, :comments),
+        order_by: [desc: count(c.id)],
+        group_by: p.id,
+        select: p
+
+      # Test the sort order:
+      # Page 1: Body 6, Body 5, Body 4, Body 3, Body 2
+      # Page 2: Body 1, Body 7
+
+      page = Scrivener.Ecto.Repo.paginate(query, %{"page" => 1})
+      assert List.first(page.entries).body == "Body 6"
+      page = Scrivener.Ecto.Repo.paginate(query, %{"page" => 2, "last_seen_id" => last_seen_id})
+      assert List.first(page.entries).body == "Body 1"
+    end
+
     test "paginates an unconstrained query" do
       create_posts()
 
@@ -211,7 +293,8 @@ defmodule Scrivener.Paginator.Ecto.QueryTest do
       config = %Scrivener.Config{
         module: Scrivener.Ecto.Repo,
         page_number: 2,
-        page_size: 4
+        page_size: 4,
+        last_seen_id: 0
       }
 
       page =


### PR DESCRIPTION
This adds a new pagination method using a new parameter called "last_seen_id". The goal is to make sure records are ordered correctly across pages. Example usage:

```
def list_posts(%{"page" => page, "last_seen_id" => last_seen_id} = params)
  query =
    from p in Post,
    left_join: v in assoc(p, :votes),
    order_by: [desc: count(v.id)],
    group_by: p.id,
    select: p

  Repo.paginate(query, params)
end
```

Behind the scenes, this makes the `entries` function use `where: p.id > ^last_seen_id`, ensuring that no records are cut off from the query results (i.e. when using offset).

This should be a non-breaking change. If "last_seen_id" is not provided, the default lookup method using offset is used.

Requires drewolson/scrivener#51. Resolves #20, #25 and #31.