### PR TITLE
Fixing total entries error for group by on field other than id with

### DIFF
--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -39,27 +39,24 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
     total_entries || 0
   end
 
+  defp prepare_select(
+    %{
+      group_bys: [
+        %Ecto.Query.QueryExpr{
+          expr: [
+            {{:., [], [{:&, [], [source_index]}, field]}, [], []} | _
+          ]
+        } | _
+      ]
+    } = query
+  ) do
+    query
+    |> exclude(:select)
+    |> select([x: source_index], struct(x, ^[field]))
+  end
   defp prepare_select(query) do
-    try do
-      query
-      |> count
-      |> Ecto.Query.Planner.prepare_sources(nil)
-
-      query
-    rescue
-      e in Ecto.SubQueryError ->
-        case e do
-          %{
-            exception: %{
-              message: "subquery must select a source (t), a field (t.field) or a map" <> _rest
-            }
-          } ->
-            query
-            |> exclude(:select)
-          _ ->
-            raise e
-        end
-    end
+    query
+    |> exclude(:select)
   end
 
   defp count(query) do

--- a/test/scrivener/paginator/ecto/query_test.exs
+++ b/test/scrivener/paginator/ecto/query_test.exs
@@ -224,7 +224,20 @@ defmodule Scrivener.Paginator.Ecto.QueryTest do
         Post
         |> join(:inner, [p], c in assoc(p, :comments))
         |> group_by([p, c], c.body)
-        |> select([p, c], (c.body))
+        |> select([p, c], ({c.body, count("*")}))
+        |> Scrivener.Ecto.Repo.paginate
+
+      assert page.total_entries == 2
+    end
+
+    test "can be used with compound group by clause" do
+      create_posts()
+
+      page =
+        Post
+        |> join(:inner, [p], c in assoc(p, :comments))
+        |> group_by([p, c], [c.body, p.title])
+        |> select([p, c], ({c.body, p.title, count("*")}))
         |> Scrivener.Ecto.Repo.paginate
 
       assert page.total_entries == 2


### PR DESCRIPTION
count or sum in select

With https://github.com/drewolson/scrivener_ecto/pull/39, I partially
fixed the issue with grouping by field other than id, but then I
realized that it would still not work if there was a count or sum in the
select.

The is a more complete solution. If there is a group by clause, it
uses the first column in the group by clause for the total entries
select.

Fixes #35
Fixes #39