### PR TITLE
Add total_entries option

### DIFF
--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -8,7 +8,7 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
   @spec paginate(Ecto.Query.t, Scrivener.Config.t) :: Scrivener.Page.t
   def paginate(query, %Config{page_size: page_size, page_number: page_number, module: repo, caller: caller, options: options}) do
     options = options || []
-    total_entries = Keyword.get(options, :total_entries, total_entries(query, repo, caller))
+    total_entries = options[:total_entries] || total_entries(query, repo, caller)
     
     %Page{
       page_size: page_size,

--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -6,9 +6,10 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
   @moduledoc false
 
   @spec paginate(Ecto.Query.t, Scrivener.Config.t) :: Scrivener.Page.t
-  def paginate(query, %Config{page_size: page_size, page_number: page_number, module: repo, caller: caller}) do
-    total_entries = total_entries(query, repo, caller)
-
+  def paginate(query, %Config{page_size: page_size, page_number: page_number, module: repo, caller: caller, options: options}) do
+    options = options || []
+    total_entries = Keyword.get(options, :total_entries, total_entries(query, repo, caller))
+    
     %Page{
       page_size: page_size,
       page_number: page_number,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Scrivener.Ecto.Mixfile do
   def project do
     [
       app: :scrivener_ecto,
-      version: "1.3.0-dev",
+      version: "1.3.1-dev",
       elixir: "~> 1.3",
       elixirc_paths: elixirc_paths(Mix.env),
       package: package(),

--- a/test/scrivener/paginator/ecto/query_test.exs
+++ b/test/scrivener/paginator/ecto/query_test.exs
@@ -181,6 +181,21 @@ defmodule Scrivener.Paginator.Ecto.QueryTest do
       assert page.page_size == 10
     end
 
+    test "will respect the total_entries configuration" do
+      config = %Scrivener.Config{
+        module: Scrivener.Ecto.Repo,
+        page_number: 2,
+        page_size: 4,
+        options: [total_entries: 130]
+      }
+      page =
+        Post
+        |> Post.published
+        |> Scrivener.paginate(config)
+
+      assert page.total_entries == 130
+    end
+
     test "can be used on a table with any primary key" do
       create_key_values()
 


### PR DESCRIPTION
## Purpose
The `count` query can be slow in some cases (see: https://wiki.postgresql.org/wiki/Slow_Counting). So in order to provide a custom way to calculate the total entries we can add a `total_entries` option to the configuration.

## Solution
- Add options support so we don't need to send a PR to https://github.com/drewolson/scrivener in order to get a new configuration option.
- Add the total_entries options.

## Status
- [x] Tests still passing
- [x] Added test to cover the new behavior