### PR TITLE
added options to entries function so offset can be optionally dynamic

### DIFF
--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -22,14 +22,14 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
     %Page{
       page_size: page_size,
       page_number: page_number,
-      entries: entries(query, repo, page_number, page_size, caller),
+      entries: entries(query, repo, page_number, page_size, caller, options),
       total_entries: total_entries,
       total_pages: total_pages
     }
   end
 
-  defp entries(query, repo, page_number, page_size, caller) do
-    offset = page_size * (page_number - 1)
+  defp entries(query, repo, page_number, page_size, caller, options \\ []) do
+    offset = if options[:offset] != nil, do: options[:offset], else: page_size * (page_number - 1)
 
     query
     |> limit(^page_size)


### PR DESCRIPTION
We are using scrivener for pagination within our application. The content we are pulling is mostly dynamic and we have an issue of the paging not always being accurate. For example if we want to pull 20 items and only 15 return, we would have to do the first call again to see if there are any new items and get back duplicate data or we say page 2 and it starts at 21. We have made the offset to now be optionally dynamic for situations like this when you would want to specify the offset manually as we will in most cases. Of course if the offset is not supplied, it will resort to using the current offset calculation based on page number and size.