### PR TITLE
Introduce a happy path for queries that don't need subquery.

### DIFF
--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -42,14 +42,13 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
       query
       |> exclude(:preload)
       |> exclude(:order_by)
-      |> prepare_select
-      |> count
+      |> aggregate()
       |> repo.one(caller: caller)
 
     total_entries || 0
   end
 
-  defp prepare_select(
+  defp aggregate(
          %{
            group_bys: [
              %Ecto.Query.QueryExpr{
@@ -64,11 +63,13 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
     query
     |> exclude(:select)
     |> select([{x, source_index}], struct(x, ^[field]))
+    |> count()
   end
 
-  defp prepare_select(query) do
+  defp aggregate(query) do
     query
     |> exclude(:select)
+    |> select(count("*"))
   end
 
   defp count(query) do


### PR DESCRIPTION
Subqueries are very slow for certain types of counts.

We had a table with a few hundred thousand records that was completely unscoped, but the generated query still used a subquery -- it took about 3s to execute.

With this patch, a happy path is added for queries not using `group_by`, which will run a much simpler `count(*)`. In our case this sped up the query significantly (~100ms to run).