### PR TITLE
Remove instruction for adding to `applications`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,14 @@ page =
 
 ## Installation
 
-Add `scrivener_ecto` to your `mix.exs` `applications` and `dependencies`.
+Add `scrivener_ecto` to your `mix.exs` `deps`.
 
 ```elixir
-def application do
-  [applications: [:scrivener_ecto]]
+defp deps do
+  [
+    {:scrivener_ecto, "~> 2.0"}
+  ]
 end
-```
-
-```elixir
-[{:scrivener_ecto, "~> 2.0"}]
 ```
 
 ## Contributing


### PR DESCRIPTION
Starting with Elixir 1.4, packages no longer needs (and probably shouldn't) be added to `applications` list.

I see that there's already a PR for this change. Since you aren't planing on actively maintaining this package, would you be willing to help maintain it?