### PR TITLE
Fix warnings on elixir 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 otp_release:
   - 23.0
 elixir:
-  - 1.10.3
+  - 1.11.1
 before_script:
   - export SCRIVENER_ECTO_DB_USER=postgres
   - MIX_ENV=test mix db.reset

--- a/mix.exs
+++ b/mix.exs
@@ -32,12 +32,9 @@ defmodule Scrivener.Ecto.Mixfile do
 
   def application do
     [
-      applications: applications(Mix.env())
+      extra_applications: [:logger]
     ]
   end
-
-  defp applications(:test), do: [:scrivener, :postgrex, :ecto, :logger, :telemetry]
-  defp applications(_), do: [:scrivener, :logger]
 
   defp deps do
     [


### PR DESCRIPTION
Currently, when we build the lib with elixir 1.11, we have the following warnings:
```
warning: Ecto.Query.Builder.Select.fields!/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query.Builder.Select]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:81

warning: Ecto.Query.Builder.Select.apply/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query.Builder.Select]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:94

warning: Ecto.Query.Builder.Select.apply/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query.Builder.Select]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:88

warning: Ecto.Query.Builder.Select.apply/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query.Builder.Select]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:81

warning: Ecto.Query.Builder.LimitOffset.apply/3 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query.Builder.LimitOffset]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:44

warning: Ecto.Query.subquery/1 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:93

warning: Ecto.Query.select/3 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:81

warning: Ecto.Query.select/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:94

warning: Ecto.Query.select/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:88

warning: Ecto.Query.offset/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:43

warning: Ecto.Query.limit/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:44

warning: Ecto.Query.exclude/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:87

warning: Ecto.Query.exclude/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:80

warning: Ecto.Query.exclude/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:63

warning: Ecto.Query.exclude/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:54

warning: Ecto.Query.exclude/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Query]] to your "def project" in mix.exs

  lib/scrivener/paginater/ecto/query.ex:53

warning: Ecto.Queryable.to_query/1 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Queryable]] to your "def project" in mix.exs

  lib/scrivener/paginater/atom.ex:7
```