### PR TITLE
Allow repo opts to be passed to paginate/2

### DIFF
--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -37,23 +37,23 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
 
   defp entries(query, repo, page_number, _, page_size, caller, options) do
     offset = Keyword.get_lazy(options, :offset, fn -> page_size * (page_number - 1) end)
-    prefix = options[:prefix]
+    {prefix, options} = Keyword.pop(options, :prefix)
 
     query
     |> offset(^offset)
     |> limit(^page_size)
-    |> all(repo, caller, prefix)
+    |> all(repo, caller, prefix, options)
   end
 
   defp total_entries(query, repo, caller, options) do
-    prefix = options[:prefix]
+    {prefix, options} = Keyword.pop(options, :prefix)
 
     total_entries =
       query
       |> exclude(:preload)
       |> exclude(:order_by)
       |> aggregate()
-      |> one(repo, caller, prefix)
+      |> one(repo, caller, prefix, options)
 
     total_entries || 0
   end
@@ -100,19 +100,23 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
     (total_entries / page_size) |> Float.ceil() |> round
   end
 
-  defp all(query, repo, caller, nil) do
-    repo.all(query, caller: caller)
+  defp all(query, repo, caller, nil, options) do
+    options = Keyword.merge(options, caller: caller)
+    repo.all(query, options)
   end
 
-  defp all(query, repo, caller, prefix) do
-    repo.all(query, caller: caller, prefix: prefix)
+  defp all(query, repo, caller, prefix, options) do
+    options = Keyword.merge(options, caller: caller, prefix: prefix)
+    repo.all(query, options)
   end
 
-  defp one(query, repo, caller, nil) do
-    repo.one(query, caller: caller)
+  defp one(query, repo, caller, nil, options) do
+    options = Keyword.merge(options, caller: caller)
+    repo.one(query, options)
   end
 
-  defp one(query, repo, caller, prefix) do
-    repo.one(query, caller: caller, prefix: prefix)
+  defp one(query, repo, caller, prefix, options) do
+    options = Keyword.merge(options, caller: caller, prefix: prefix)
+    repo.one(query, options)
   end
 end

--- a/test/scrivener/paginator/ecto/query_test.exs
+++ b/test/scrivener/paginator/ecto/query_test.exs
@@ -1,6 +1,6 @@
 defmodule Scrivener.Paginator.Ecto.QueryTest do
   use Scrivener.Ecto.TestCase
-
+  import ExUnit.CaptureLog
   alias Scrivener.Ecto.{Comment, KeyValue, Post, User}
 
   defp create_posts do
@@ -444,6 +444,16 @@ defmodule Scrivener.Paginator.Ecto.QueryTest do
       assert page_tenant_2.page_number == 1
       assert page_tenant_2.total_entries == 2
       assert page_tenant_2.total_pages == 1
+    end
+
+    test "accepts repo options" do
+      log = capture_log(fn -> Scrivener.Ecto.Repo.paginate(Post, options: [log: true]) end)
+
+      assert log =~
+               "SELECT p0.\"id\", p0.\"title\", p0.\"body\", p0.\"published\", p0.\"inserted_at\", p0.\"updated_at\" FROM \"posts\" AS p0 LIMIT $1 OFFSET $2"
+
+      log = capture_log(fn -> Scrivener.Ecto.Repo.paginate(Post, options: [log: false]) end)
+      assert log == ""
     end
   end
 end


### PR DESCRIPTION
Right now we only can pass `:prefix` repo opt to `Repo.paginate/2` but it should behave like a normal repo operation where the user can pass arbitrary/predefined repo options such as those indicated in https://hexdocs.pm/ecto/Ecto.Repo.html#module-shared-options

For example, we should be able to pass `:log` and `:admin` as opts to `Repo.paginate/2` like this:
```elixir
Scrivener.Ecto.Repo.paginate(Post, options: [log: true, admin: true])
```

Now the query will be logged and we can use the arbitrary opts such as admin in the `prepare_query/3` callback like so:
```elixir
@impl true
def prepare_query(_operation, query, opts) do
  if opts[:admin] do
    {query, opts}
  else
    query = from(x in query, where: is_nil(x.deleted_at))
    {query, opts}
  end
end
``` 