### PR TITLE
Remove QueryExpr pattern match to support Ecto 3.12.0

### DIFF
--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -67,7 +67,7 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
   defp aggregate(
          %{
            group_bys: [
-             %Ecto.Query.QueryExpr{
+             %{
                expr: [
                  {{:., [], [{:&, [], [source_index]}, field]}, [], []} | _
                ]


### PR DESCRIPTION
Ecto replaced `Ecto.Query.QueryExpr` with `Ecto.Query.ByExpr` since version 3.12.0:

> distinct, group_by, order_by and window expressions use the new Ecto.Query.ByExpr struct rather than the old Ecto.Query.QueryExpr struct

See: https://hexdocs.pm/ecto/changelog.html#v3-12-0-2024-08-12

I thought about adding another function and pattern match `Ecto.Query.ByExpr`, but the module is only available since Ecto 3.12.0.