### PR TITLE
Remove QueryExpr Pattern Match to support Ecto 3.12.0

### DIFF
--- a/lib/scrivener/paginater/ecto/query.ex
+++ b/lib/scrivener/paginater/ecto/query.ex
@@ -67,7 +67,7 @@ defimpl Scrivener.Paginater, for: Ecto.Query do
   defp aggregate(
          %{
            group_bys: [
-             %Ecto.Query.QueryExpr{
+             %{
                expr: [
                  {{:., [], [{:&, [], [source_index]}, field]}, [], []} | _
                ]


### PR DESCRIPTION
This PR is to remove query expr pattern match